### PR TITLE
Use assert feature in StateFile and Task

### DIFF
--- a/src/main/java/pyrite/StateFile.java
+++ b/src/main/java/pyrite/StateFile.java
@@ -47,6 +47,7 @@ public class StateFile {
      * @return TaskList with loaded state.
      */
     public TaskList loadState(TaskList tasks) {
+        assert tasks != null : "Default TaskList cannot be null.";
         try {
             TaskList loadedTasks = this.loadObject();
             return loadedTasks;
@@ -65,6 +66,7 @@ public class StateFile {
      * @return Error message if any.
      */
     public String saveState(TaskList tasks) {
+        assert tasks != null : "TaskList to save cannot be null.";
         try {
             this.saveObject(tasks);
         } catch (IOException e) {

--- a/src/main/java/pyrite/task/Task.java
+++ b/src/main/java/pyrite/task/Task.java
@@ -22,6 +22,7 @@ public class Task implements Serializable {
      * @param description Description of the task.
      */
     public Task(String description) {
+        assert description != "" : "Description cannot be empty.";
         this.description = description;
         this.status = Status.NOT_DONE;
     }


### PR DESCRIPTION
There are no assertions in the code.

Assertions document assumptions and surface incorrect ones.

Add assertions to points in the code where assumptions are being made.

Several methods in StateFile and Task make assumptions about their input parameters, which should be documented.